### PR TITLE
Private data endpoints should be JWT only, this fixes auth for these.

### DIFF
--- a/src/api/v1/routes.ts
+++ b/src/api/v1/routes.ts
@@ -98,10 +98,10 @@ export const setupV1routes = (app: core.Express) => {
 	app.delete("/v1/user/:id", isUserAppJwtAuthenticated, user.deleteAccount)
 
 	// Private
-	app.get("/v1/user/private/:id", isUserAuthenticated(ApiKeyAccessType.Read), priv.get)
-	app.patch("/v1/user/private/:id", isUserAuthenticated(ApiKeyAccessType.Write), validateBody(priv.validatePrivateSchema), priv.update)
-	app.get("/v1/private/:id", isUserAuthenticated(ApiKeyAccessType.Read), priv.get)
-	app.patch("/v1/private/:id", isUserAuthenticated(ApiKeyAccessType.Write), validateBody(priv.validatePrivateSchema), priv.update)
+	app.get("/v1/user/private/:id", isUserAppJwtAuthenticated, priv.get)
+	app.patch("/v1/user/private/:id", isUserAppJwtAuthenticated, validateBody(priv.validatePrivateSchema), priv.update)
+	app.get("/v1/private/:id", isUserAppJwtAuthenticated, priv.get)
+	app.patch("/v1/private/:id", isUserAppJwtAuthenticated, validateBody(priv.validatePrivateSchema), priv.update)
 
 	// Friends
 	app.get("/v1/friends/", isUserAuthenticated(ApiKeyAccessType.Read), friend.getFriends)


### PR DESCRIPTION
(and apparently a newline at the end of the routes file as we've never told nano it shouldn't, whoops)
~ Emily of the TC