### PR TITLE
Remove requirement of operation time for SetUsername

### DIFF
--- a/src/api/v1/user.ts
+++ b/src/api/v1/user.ts
@@ -173,12 +173,7 @@ export const SetUsername = async (req: Request, res: Response) => {
 	const potentiallyAlreadyTakenUserDoc = await getCollection("users").findOne({ username: { $regex: "^" + newUsername + "$", $options: "i" }, uid: { $ne: res.locals.uid } });
 
 	if (potentiallyAlreadyTakenUserDoc === null) {
-		getCollection("users").updateOne({
-			uid: res.locals.uid, $or: [
-				{ lastOperationTime: null },
-				{ lastOperationTime: { $lte: res.locals.operationTime } }
-			]
-		}, { $set: { username: newUsername, lastOperationTime: res.locals.operationTime } });
+		getCollection("users").updateOne({ uid: res.locals.uid }, { $set: { username: newUsername } });
 		res.status(200).send({ success: true });
 		userLog(res.locals.uid, "Updated username to: " + newUsername);
 		return;


### PR DESCRIPTION
SetUsername is not part of the SDK's queued changes, this gets executed immediately and therefore doesn't need to be protected against race-conditions or multiple requests from different devices causing it to desynchronise