### PR TITLE
Fixes confirmation emails not sending correctly in 1.8 beta

### DIFF
--- a/src/api/v1/auth.ts
+++ b/src/api/v1/auth.ts
@@ -359,7 +359,10 @@ export const validateConfirmEmailSchema = (body: any): { success: boolean, msg: 
 	const schema = {
 		type: "object",
 		properties: {
-			uid: { type: "string", pattern: "^[a-zA-Z0-9]{64}$" },
+			// Users registering before 1.8 have a firebase user id (regex `^[A-Za-z0-9]{1,50}$`)
+			// Users registering on/after 1.8 have a new auth user id (regex `^[A-Za-z0-9]{64}$`) 
+			// At a later stage it's probably best to merge those two into an OR check rather than this broad condition
+			uid: { type: "string", pattern: "^[a-zA-Z0-9]{1,64}$" },
 			key: { type: "string", pattern: "^[a-zA-Z0-9]{128}$" }
 		},
 		nullable: false,


### PR DESCRIPTION
Contains 2 fixes:
1) Regex for user id is different depending if user registered pre 1.8 (firebase) or on/after 1.8. 
2) Confirmation email is sent in several situations where there is no confirmation code set, thus sending the email for code `undefined`. Fixed by guarding in the function that sends the mail.

As discussed on Discord but added here for brevity:
> For `user.verificationCode` to be undefined there's two, maybe three possibilities: 
> 1) The user has registered through the auth2 code, and is already verified, and at that point the verification email should not have been sent.
> 2) The user has registered through firebase before 1.8, and is not yet verified. When trying to send the verification mail, the `getConfirmationKey` function has never been called on their account before, thus it does not exist yet.
> 3) The user has changed their email address. In `auth.ts`, if this succeeds this will invalidate their `user.verified` value.

As it would be used in multiple places, guarding it in the function that sends the confirmation email would make the most sense.

Additionally, users connecting through OAuth2 won't need a verify email. This is already handled correctly as their accounts are imported from Firebase, where it sets the `verified: true, oAuth2: true` settings.

Code compiles correctly, linting introduces no new errors/warnings, and passes all tests. We have however not run a manual test on it.