### PR TITLE
Add support for 6-character PluralKit IDs

### DIFF
--- a/src/modules/integrations/pk/sync.ts
+++ b/src/modules/integrations/pk/sync.ts
@@ -116,7 +116,7 @@ export const syncMemberToPk = async (options: syncOptions, spMemberId: string, t
 		}
 
 		const pkId: string | undefined | null = spMemberResult.pkId;
-		if (pkId && pkId.length === 5) {
+		if (pkId && ( pkId.length === 5 || pkId.length === 6 ) ) {
 			const getRequest: PkRequest = { path: `https://api.pluralkit.me/v2/members/${spMemberResult.pkId}`, token, response: null, data: undefined, type: PkRequestType.Get, id: "" };
 			const pkMemberResult = memberData ?? (await addPendingRequest(getRequest));
 


### PR DESCRIPTION
Should fix bug reported multiple times since the PluralKit change. Basing directly on release because this is a hotfix.