### PR TITLE
Fix member notification strings containing custom front strings

### DIFF
--- a/src/modules/events/frontChange.ts
+++ b/src/modules/events/frontChange.ts
@@ -209,9 +209,6 @@ export const notifyFrontDue = async (uid: string, _event: any) => {
 			const accessResult = await getDocumentAccess(friend.frienduid, frontStatus, "frontStatuses")
 			if (accessResult.access === true) {
 				customFronterNames.push(frontStatus.name)
-				if (frontStatus.preventsFrontNotifs !== true) {
-					fronterNotificationNames.push(frontStatus.name)
-				}
 			}
 		}
 


### PR DESCRIPTION
- Custom fronts do not currently have prevent front notifs so we can safely remove this line.
- Custom fronts were registering under the member front string, as well as the custom front string.