### PR TITLE
Fix deleting a member not properly removing them from groups

### DIFF
--- a/src/api/v1/member.ts
+++ b/src/api/v1/member.ts
@@ -279,15 +279,6 @@ export const del = async (req: Request, res: Response) => {
 		frontChange(res.locals.uid, true, req.params.id, false)
 	}
 
-	// Delete this member from any groups they're in
-	getCollection("groups")
-		.find({ uid: res.locals.uid })
-		.forEach((group: any) => {
-			const members: string[] = group.members ?? []
-			const newMembers = members.filter((member) => member != req.params.id)
-			getCollection("groups").updateOne({ uid: res.locals.uid, _id: parseId(group._id) }, { $set: { members: newMembers } })
-		})
-
 	// @ts-ignore
 	getCollection("groups").updateMany({ uid: res.locals.uid }, { $pull: { members: req.params.id } })
 


### PR DESCRIPTION
Removed code is legacy code before we added the $Pull operator, unsure how the legacy code was never removed